### PR TITLE
Fix Next.js config and serve uploaded files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@
 node_modules
 .next
 .env
-data
+/data/
 *.log

--- a/app/data/[...path]/route.ts
+++ b/app/data/[...path]/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from 'next/server';
+import path from 'path';
+import { promises as fs } from 'fs';
+
+const MIME_MAP: Record<string, string> = {
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.heic': 'image/heic',
+  '.pdf': 'application/pdf',
+};
+
+function resolveUploadsPath() {
+  const dataDir = process.env.DATA_DIR || path.resolve(process.cwd(), 'data');
+  return path.resolve(path.join(dataDir, 'uploads'));
+}
+
+function contentTypeFor(filePath: string) {
+  const ext = path.extname(filePath).toLowerCase();
+  return MIME_MAP[ext] || 'application/octet-stream';
+}
+
+export const runtime = 'nodejs';
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: { path?: string[] } }
+) {
+  const segments = params.path || [];
+  if (segments.length === 0 || segments[0] !== 'uploads') {
+    return new NextResponse('Not found', { status: 404 });
+  }
+  const uploadsRoot = resolveUploadsPath();
+  const relativeSegments = segments.slice(1);
+  const normalizedRoot = uploadsRoot.endsWith(path.sep) ? uploadsRoot : uploadsRoot + path.sep;
+  if (relativeSegments.length === 0) {
+    return new NextResponse('Not found', { status: 404 });
+  }
+  const requestedPath = path.join(uploadsRoot, ...relativeSegments);
+  const resolved = path.resolve(requestedPath);
+  if (!resolved.startsWith(normalizedRoot)) {
+    return new NextResponse('Not found', { status: 404 });
+  }
+  try {
+    const stat = await fs.stat(resolved);
+    if (!stat.isFile()) {
+      return new NextResponse('Not found', { status: 404 });
+    }
+    const data = await fs.readFile(resolved);
+    return new NextResponse(data, {
+      headers: {
+        'Content-Type': contentTypeFor(resolved),
+        'Content-Length': stat.size.toString(),
+        'Cache-Control': 'public, max-age=31536000, immutable',
+      },
+    });
+  } catch {
+    return new NextResponse('Not found', { status: 404 });
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 'use client';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
+import Image from 'next/image';
 type RecordItem = {
   id: string;
   filename: string;
@@ -18,12 +19,14 @@ export default function Home() {
   const [search, setSearch] = useState<string>('');
   const [items, setItems] = useState<RecordItem[]>([]);
   const [loading, setLoading] = useState(false);
-  async function refresh() {
+  const refresh = useCallback(async () => {
     const res = await fetch('/api/search?query=' + encodeURIComponent(search));
     const data = await res.json();
     setItems(data.items || []);
-  }
-  useEffect(() => { refresh(); }, [search]);
+  }, [search]);
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (!file) return;
@@ -79,7 +82,13 @@ export default function Home() {
         {items.map(it => (
           <div key={it.id} className="card">
             <div style={{display:'flex',gap:12}}>
-              <img src={it.path.replace(/^\./,'')} alt={it.title || it.filename} width={96} height={96} style={{objectFit:'cover',borderRadius:8}}/>
+              <Image
+                src={it.path.replace(/^\./,'')}
+                alt={it.title || it.filename}
+                width={96}
+                height={96}
+                style={{objectFit:'cover',borderRadius:8}}
+              />
               <div style={{flex:1}}>
                 <div style={{fontWeight:600}}>{it.title || it.filename}</div>
                 <div style={{fontSize:12,color:'#6b7280'}}>{new Date(it.createdAt).toLocaleString()}</div>

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,8 +2,9 @@
 const nextConfig = {
   experimental: {
     serverActions: {
-      allowedOrigins: ['*']
-    }
+      allowedOrigins: ['*'],
+    },
   },
-}
-module.exports = nextConfig
+};
+
+export default nextConfig;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,12 +19,19 @@
     "forceConsistentCasingInFileNames": true,
     "types": [
       "node"
+    ],
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
     ]
   },
   "include": [
     "next-env.d.ts",
     "**/*.ts",
-    "**/*.tsx"
+    "**/*.tsx",
+    ".next/types/**/*.ts"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
## Summary
- export the Next.js config via ESM syntax so Next lint/build can load it
- add a server route that streams uploaded files from the data/uploads directory with basic MIME handling
- refresh the home page to use a memoised refresh handler and Next's Image component, and adjust ignores/tsconfig after Next lint

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4230265f8832580569ed42ef7a9d7